### PR TITLE
Add support for custom subscribe annotations

### DIFF
--- a/api/src/main/java/net/kyori/event/EventSubscriber.java
+++ b/api/src/main/java/net/kyori/event/EventSubscriber.java
@@ -55,7 +55,7 @@ public interface EventSubscriber<E> {
   }
 
   /**
-   * Gets if cancelled event should be posted to this subscriber.
+   * Gets if cancelled events should be posted to this subscriber.
    *
    * @return if cancelled events should be posted
    */

--- a/method-asm/src/test/java/net/kyori/event/method/asm/ASMEventBusTest.java
+++ b/method-asm/src/test/java/net/kyori/event/method/asm/ASMEventBusTest.java
@@ -24,10 +24,10 @@
 package net.kyori.event.method.asm;
 
 import net.kyori.event.Cancellable;
-import net.kyori.event.method.IgnoreCancelled;
 import net.kyori.event.method.MethodEventBus;
 import net.kyori.event.method.SimpleMethodEventBus;
-import net.kyori.event.method.Subscribe;
+import net.kyori.event.method.annotation.IgnoreCancelled;
+import net.kyori.event.method.annotation.Subscribe;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/method/src/main/java/net/kyori/event/method/MethodEventBus.java
+++ b/method/src/main/java/net/kyori/event/method/MethodEventBus.java
@@ -26,6 +26,8 @@ package net.kyori.event.method;
 import net.kyori.event.EventBus;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.lang.reflect.Method;
+
 /**
  * Extension of {@link EventBus} which supports defining event subscribers as methods in a class.
  *
@@ -34,14 +36,15 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 public interface MethodEventBus<E, L> extends EventBus<E> {
   /**
-   * Registers all methods annotated with {@link Subscribe} on {@code listener} to receive events.
+   * Registers all methods determined to be {@link MethodScanner#shouldRegister(Object, Method) valid}
+   * on the {@code listener} to receive events.
    *
    * @param listener the listener
    */
   void register(final @NonNull L listener);
 
   /**
-   * Unregisters all subscriber methods on a registered {@code listener}.
+   * Unregisters all methods on a registered {@code listener}.
    *
    * @param listener the listener
    */

--- a/method/src/main/java/net/kyori/event/method/MethodScanner.java
+++ b/method/src/main/java/net/kyori/event/method/MethodScanner.java
@@ -23,19 +23,38 @@
  */
 package net.kyori.event.method;
 
-import net.kyori.event.Cancellable;
+import net.kyori.event.PostOrder;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.reflect.Method;
 
 /**
- * Marks an event subscriber that should not receive events even if they have been {@link Cancellable#cancelled() cancelled}.
+ * Determines which methods on a listener should be registered
+ * as subscribers, and what properties they should have.
+ *
+ * @param <L> the listener type
  */
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface IgnoreCancelled {
+public interface MethodScanner<L> {
+  /**
+   * Gets if the factory should generate a subscriber for this method.
+   *
+   * @param listener the listener being scanned
+   * @param method the method declaration being considered
+   * @return if a subscriber should be registered
+   */
+  boolean shouldRegister(final @NonNull L listener, final @NonNull Method method);
+
+  /**
+   * Gets the {@link PostOrder} the resultant subscriber should be called at.
+   *
+   * @return the post order of this subscriber
+   */
+  @NonNull PostOrder postOrder(final @NonNull L listener, final @NonNull Method method);
+
+  /**
+   * Gets if cancelled events should be posted to the resultant subscriber.
+   *
+   * @return if cancelled events should be posted
+   */
+  boolean consumeCancelledEvents(final @NonNull L listener, final @NonNull Method method);
 }

--- a/method/src/main/java/net/kyori/event/method/annotation/IgnoreCancelled.java
+++ b/method/src/main/java/net/kyori/event/method/annotation/IgnoreCancelled.java
@@ -21,9 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.event.method;
+package net.kyori.event.method.annotation;
 
-import net.kyori.event.PostOrder;
+import net.kyori.event.Cancellable;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -32,18 +32,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a method as an event subscriber.
- *
- * @see IgnoreCancelled
+ * Marks an event subscriber that should not receive events even if they have been {@link Cancellable#cancelled() cancelled}.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Subscribe {
-  /**
-   * Gets the post order.
-   *
-   * @return the post order
-   */
-  PostOrder value() default PostOrder.NORMAL;
+public @interface IgnoreCancelled {
 }

--- a/method/src/main/java/net/kyori/event/method/annotation/Subscribe.java
+++ b/method/src/main/java/net/kyori/event/method/annotation/Subscribe.java
@@ -21,32 +21,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package net.kyori.event.method;
+package net.kyori.event.method.annotation;
 
-import net.kyori.event.SimpleEventBus;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import net.kyori.event.PostOrder;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * A simple implementation of a method event bus.
+ * Marks a method as an event subscriber.
+ *
+ * @see IgnoreCancelled
  */
-public class SimpleMethodEventBus<E, L> extends SimpleEventBus<E> implements MethodEventBus<E, L> {
-  private final MethodEventSubscriberFactory<E, L> factory;
-
-  public SimpleMethodEventBus(final EventExecutor.@NonNull Factory<E, L> factory) {
-    this.factory = new MethodEventSubscriberFactory<>(factory);
-  }
-
-  public SimpleMethodEventBus(final EventExecutor.@NonNull Factory<E, L> factory, final @NonNull MethodScanner<L> methodScanner) {
-    this.factory = new MethodEventSubscriberFactory<>(factory, methodScanner);
-  }
-
-  @Override
-  public void register(final @NonNull L listener) {
-    this.factory.findSubscribers(listener, this::register);
-  }
-
-  @Override
-  public void unregister(final @NonNull L listener) {
-    this.unregisterMatching(h -> h instanceof MethodEventSubscriber && ((MethodEventSubscriber) h).listener() == listener);
-  }
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Subscribe {
+  /**
+   * Gets the post order.
+   *
+   * @return the post order
+   */
+  PostOrder value() default PostOrder.NORMAL;
 }

--- a/method/src/test/java/net/kyori/event/method/MethodEventBusTest.java
+++ b/method/src/test/java/net/kyori/event/method/MethodEventBusTest.java
@@ -24,6 +24,8 @@
 package net.kyori.event.method;
 
 import net.kyori.event.Cancellable;
+import net.kyori.event.method.annotation.IgnoreCancelled;
+import net.kyori.event.method.annotation.Subscribe;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/method/src/test/java/net/kyori/event/method/MethodEventBusTestWithType.java
+++ b/method/src/test/java/net/kyori/event/method/MethodEventBusTestWithType.java
@@ -25,6 +25,7 @@ package net.kyori.event.method;
 
 import com.google.common.reflect.TypeToken;
 import net.kyori.event.ReifiedEvent;
+import net.kyori.event.method.annotation.Subscribe;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Not too sure about the `MethodScanner` name - but I couldn't really think of anything better at the time of writing.