### PR TITLE
MethodHandle#invokeWithArguments --> MethodHandle#invoke

### DIFF
--- a/method/src/main/java/net/kyori/event/method/MethodHandleEventExecutorFactory.java
+++ b/method/src/main/java/net/kyori/event/method/MethodHandleEventExecutorFactory.java
@@ -41,6 +41,6 @@ public final class MethodHandleEventExecutorFactory<E, L> implements EventExecut
     final MethodHandle handle = MethodHandles.publicLookup()
       .unreflect(method)
       .bindTo(object);
-    return (listener, event) -> handle.invokeWithArguments(event);
+    return (listener, event) -> handle.invoke(event);
   }
 }


### PR DESCRIPTION
Accidentally used the wrong method in the original commit. 